### PR TITLE
26.2 (fabric, Mojang official mappings)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,6 @@
 import me.modmuss50.mpp.ReleaseType
+import net.fabricmc.loom.task.RemapJarTask
+import org.gradle.jvm.tasks.Jar
 import java.util.*
 
 plugins {
@@ -10,6 +12,17 @@ plugins {
 
 val minecraft = stonecutter.current.version
 val loader = loom.platform.get().name.lowercase()
+// 26.2+ is unobfuscated: no Yarn/Mojang mappings are published, so loom has
+// nothing to remap and does not register a remapJar task. We compile directly
+// against the official-names Minecraft jar (no mappings(...) dependency, no
+// access widener) and ship the plain jar as the final artifact. Toggled
+// per-version via the fabric.loom.disableObfuscation gradle property
+// (see versions/26.2-fabric). Base loom stays in the plugins block so the loom
+// extension accessor is generated; loom-specific configurations/tasks that are
+// not registered in no-remap mode are referenced by name (tasks.named/add) and
+// only used when !noRemap. architectury-plugin 3.5+ tolerates the absent
+// remapJar task that older versions hard-required.
+val noRemap = stonecutter.eval(minecraft, ">=26.2")
 
 version = "${mod.version}+$minecraft"
 group = mod.group
@@ -32,25 +45,33 @@ repositories {
     maven("https://api.modrinth.com/maven")
 }
 dependencies {
-    minecraft("com.mojang:minecraft:$minecraft")
+    add("minecraft", "com.mojang:minecraft:$minecraft")
 
 
-    modCompileOnly("maven.modrinth:elytra-recast:${mod.dep("elytra_recast")}")
+    if (stonecutter.eval(minecraft, "<26.2")) {
+        add("modCompileOnly", "maven.modrinth:elytra-recast:${mod.dep("elytra_recast")}")
+    }
 
     if (loader == "fabric") {
-        modImplementation("net.fabricmc:fabric-loader:${mod.dep("fabric_loader")}")
-        mappings("net.fabricmc:yarn:$minecraft+build.${mod.dep("yarn_build")}:v2")
-        modCompileOnly("com.terraformersmc:modmenu:${mod.dep("modmenu_version")}")
-
-        //some features (like automatic resource loading from non vanilla namespaces) work only with fabric API installed
-        //for example translations from assets/modid/lang/en_us.json won't be working, same stuff with textures
-        //but we keep runtime only to not accidentally depend on fabric's api, because it doesn't exist in neo/forge
-        modImplementation("net.fabricmc.fabric-api:fabric-api:${mod.dep("fabric_version")}")
-
+        if (noRemap) {
+            // 26.2 unobfuscated: no mappings, plain implementation/compileOnly (no
+            // mod* remap configurations), plain jar is the artifact (no remapJar).
+            implementation("net.fabricmc:fabric-loader:${mod.dep("fabric_loader")}")
+            compileOnly("com.terraformersmc:modmenu:${mod.dep("modmenu_version")}")
+            implementation("net.fabricmc.fabric-api:fabric-api:${mod.dep("fabric_version")}")
+        } else {
+            add("mappings", "net.fabricmc:yarn:$minecraft+build.${mod.dep("yarn_build")}:v2")
+            add("modImplementation", "net.fabricmc:fabric-loader:${mod.dep("fabric_loader")}")
+            add("modCompileOnly", "com.terraformersmc:modmenu:${mod.dep("modmenu_version")}")
+            //some features (like automatic resource loading from non vanilla namespaces) work only with fabric API installed
+            //for example translations from assets/modid/lang/en_us.json won't be working, same stuff with textures
+            //but we keep runtime only to not accidentally depend on fabric's api, because it doesn't exist in neo/forge
+            add("modImplementation", "net.fabricmc.fabric-api:fabric-api:${mod.dep("fabric_version")}")
+        }
     }
     if (loader == "forge") {
         "forge"("net.minecraftforge:forge:${minecraft}-${mod.dep("forge_loader")}")
-        mappings("net.fabricmc:yarn:$minecraft+build.${mod.dep("yarn_build")}:v2")
+        add("mappings", "net.fabricmc:yarn:$minecraft+build.${mod.dep("yarn_build")}:v2")
 
         "io.github.llamalad7:mixinextras-forge:${mod.dep("mixin_extras")}".let {
             implementation(it)
@@ -59,7 +80,7 @@ dependencies {
     }
     if (loader == "neoforge") {
         "neoForge"("net.neoforged:neoforge:${mod.dep("neoforge_loader")}")
-        mappings(loom.layered {
+        add("mappings", loom.layered {
             mappings("net.fabricmc:yarn:$minecraft+build.${mod.dep("yarn_build")}:v2")
             mod.dep("neoforge_patch").takeUnless { it.startsWith('[') }?.let {
                 mappings("dev.architectury:yarn-mappings-patch-neoforge:$it")
@@ -69,7 +90,9 @@ dependencies {
 }
 
 loom {
-    accessWidenerPath = rootProject.file("src/main/resources/jjelytraswap.accesswidener")
+    if (!noRemap) {
+        accessWidenerPath = rootProject.file("src/main/resources/jjelytraswap.accesswidener")
+    }
 
     decompilers {
         get("vineflower").apply { // Adds names to lambdas - useful for mixins
@@ -95,7 +118,7 @@ publishMods {
     val curseforgeToken = localProperties.getProperty("publish.curseforgeToken", "")
 
 
-    file = project.tasks.remapJar.get().archiveFile
+    file = if (noRemap) tasks.jar.get().archiveFile else tasks.named<RemapJarTask>("remapJar").get().archiveFile
     dryRun = modrinthToken == null || curseforgeToken == null
 
     displayName = "${mod.name} ${loader.replaceFirstChar { it.uppercase() }} ${property("mod.mc_title")}-${mod.version}"
@@ -129,7 +152,11 @@ publishMods {
 
 java {
     withSourcesJar()
-    val java = if (stonecutter.eval(minecraft, ">=1.20.5")) JavaVersion.VERSION_21 else JavaVersion.VERSION_17
+    val java = when {
+        stonecutter.eval(minecraft, ">=26.2") -> JavaVersion.VERSION_25
+        stonecutter.eval(minecraft, ">=1.20.5") -> JavaVersion.VERSION_21
+        else -> JavaVersion.VERSION_17
+    }
     targetCompatibility = java
     sourceCompatibility = java
 }
@@ -144,21 +171,29 @@ tasks.shadowJar {
     archiveClassifier = "dev-shadow"
 }
 
-tasks.remapJar {
-    injectAccessWidener = true
-    input = tasks.shadowJar.get().archiveFile
-    archiveClassifier = null
-    dependsOn(tasks.shadowJar)
-}
-
-tasks.jar {
-    archiveClassifier = "dev"
+if (!noRemap) {
+    tasks.named<RemapJarTask>("remapJar") {
+        injectAccessWidener = true
+        input = tasks.shadowJar.get().archiveFile
+        archiveClassifier = null
+        dependsOn(tasks.shadowJar)
+    }
+    tasks.jar {
+        archiveClassifier = "dev"
+    }
+} else {
+    // 26.2 no-remap: the plain jar is the final artifact (no remapJar step).
+    tasks.jar {
+        archiveClassifier = null
+    }
 }
 
 val buildAndCollect = tasks.register<Copy>("buildAndCollect") {
     group = "versioned"
     description = "Must run through 'chiseledBuild'"
-    from(tasks.remapJar.get().archiveFile, tasks.remapSourcesJar.get().archiveFile)
+    val mainJar = if (noRemap) tasks.jar.get().archiveFile else tasks.named<RemapJarTask>("remapJar").get().archiveFile
+    val sourcesJar = if (noRemap) (tasks.getByName("sourcesJar") as Jar).archiveFile else tasks.named<Jar>("remapSourcesJar").get().archiveFile
+    from(mainJar, sourcesJar)
     into(rootProject.layout.buildDirectory.file("libs/${mod.version}/$loader"))
     dependsOn("build")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,7 @@ stonecutter {
         fun mc(loader: String, vararg versions: String) {
             for (version in versions) vers("$version-$loader", version)
         }
-        mc("fabric","1.21.3", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8", "1.21.9", "1.21.10", "1.21.11")
+        mc("fabric","1.21.3", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8", "1.21.9", "1.21.10", "1.21.11", "26.2")
         mc("neoforge", "1.21.3", "1.21.4", "1.21.5", "1.21.6", "1.21.7", "1.21.8", "1.21.9", "1.21.10", "1.21.11")
     }
     create(rootProject)

--- a/src/main/java/io/github/jumperonjava/jjelytraswap/ConfigScreen.java
+++ b/src/main/java/io/github/jumperonjava/jjelytraswap/ConfigScreen.java
@@ -1,3 +1,4 @@
+//? if <26.2 {
 package io.github.jumperonjava.jjelytraswap;
 
 import net.minecraft.client.gui.DrawContext;
@@ -26,3 +27,20 @@ public class ConfigScreen extends Screen {
         return new ConfigScreen(parent);
     }
 }
+//?} else {
+/*package io.github.jumperonjava.jjelytraswap;
+
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+public class ConfigScreen extends Screen {
+
+    public ConfigScreen(Screen parent) {
+        super(Component.empty());
+    }
+
+    public static ConfigScreen createConfigScreen(Screen parent) {
+        return new ConfigScreen(parent);
+    }
+}
+*///?}

--- a/src/main/java/io/github/jumperonjava/jjelytraswap/JJElytraSwapInit.java
+++ b/src/main/java/io/github/jumperonjava/jjelytraswap/JJElytraSwapInit.java
@@ -1,3 +1,4 @@
+//? if <26.2 {
 package io.github.jumperonjava.jjelytraswap;
 
 import me.lunaluna.fabric.elytrarecast.config.ElytraRecastConfig;
@@ -288,3 +289,234 @@ public class JJElytraSwapInit
 		chat.addMessage(Text.of(msg.toString()));
 	}
 }
+//?} else {
+/*package io.github.jumperonjava.jjelytraswap;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.core.Holder;
+import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.chat.Component;
+import net.minecraft.network.protocol.game.ServerboundPlayerCommandPacket;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.entity.ai.attributes.Attribute;
+import net.minecraft.world.entity.ai.attributes.Attributes;
+import net.minecraft.world.inventory.ContainerInput;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.core.component.DataComponents;
+import net.minecraft.world.item.component.ItemAttributeModifiers;
+import net.minecraft.world.item.enchantment.Enchantment;
+import net.minecraft.world.item.enchantment.EnchantmentHelper;
+import net.minecraft.world.item.enchantment.Enchantments;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Collections;
+import java.util.stream.Collectors;
+
+public class JJElytraSwapInit
+{
+	public static final String MODID = "jjelytraswap";
+	public static final Logger LOGGER = LoggerFactory.getLogger("JJElytraSwap");
+	public static ModPlatform PLATFORM = null;
+
+	public static void entrypoint(ModPlatform platform) {
+		JJElytraSwapInit.PLATFORM = platform;
+		onInitializeClient();
+	}
+	public static boolean enabled = true;
+
+	public static boolean stackHasComponent(ItemStack stack, DataComponentType<?> type) {
+		return stack.has(type);
+	}
+
+	public static void tryWearChestplate(Minecraft client) {
+		if (client.level == null || client.player == null) {
+			return;
+		}
+
+		if (client.player.getItemBySlot(EquipmentSlot.CHEST).isEmpty()) {
+			return;
+		}
+
+		var chestplateSlots = getChestplateSlots();
+
+		chestplateSlots = chestplateSlots
+				.stream()
+				.filter(slot->(getChestplateStat(client.player.getInventory().getItem(slot))>0f))
+				.sorted(
+						Comparator.comparingInt(
+								slot -> getChestplateStat(
+										client.player.getInventory().getItem(slot)
+								)
+						)
+				).collect(Collectors.toCollection(ArrayList::new));
+		Collections.reverse(chestplateSlots);
+
+		if (!chestplateSlots.isEmpty()) {
+			int bestSlot = chestplateSlots.get(0);
+			swap(bestSlot, client);
+		}
+	}
+
+	public static void tryWearElytra() {
+		if (Minecraft.getInstance().level == null || Minecraft.getInstance().player == null) {
+			return;
+		}
+
+		if (stackHasComponent(Minecraft.getInstance().player.getInventory().getItem(38),DataComponents.GLIDER)) {
+			return;
+		}
+
+		var elytraSlots = getElytraSlots();
+
+		elytraSlots.sort(Comparator.comparingInt(slot -> getElytraStat(Minecraft.getInstance().player.getInventory().getItem(slot))));
+
+		if (!elytraSlots.isEmpty()) {
+			int bestSlot = elytraSlots.get(elytraSlots.size() - 1);
+			wearElytra(bestSlot);
+		}
+	}
+
+	public static List<Integer> getElytraSlots() {
+		List<Integer> elytraSlots = new ArrayList<>();
+
+		for (int slot : slotArray()) {
+			if (stackHasComponent(Minecraft.getInstance().player.getInventory().getItem(slot),DataComponents.GLIDER)) {
+				elytraSlots.add(slot);
+			}
+		}
+		return elytraSlots;
+	}
+
+
+	public static List<Integer> getChestplateSlots() {
+		List<Integer> chestplateSlots = new ArrayList<>();
+		var client = Minecraft.getInstance();
+
+		for (int slot : slotArray()) {
+			if (isSlotChestplate(slot)) {
+				chestplateSlots.add(slot);
+			}
+		}
+
+		return chestplateSlots;
+	}
+    private static Registry<Enchantment> getEnchantmentRegistry() {
+        return Minecraft.getInstance().level.registryAccess().lookupOrThrow(Registries.ENCHANTMENT);
+	}
+
+	private static int getLevel(ResourceKey<Enchantment> key, ItemStack stack) {
+		Holder<Enchantment> enchantEntry = getEnchantmentRegistry().get(key.identifier()).orElseThrow();
+		return EnchantmentHelper.getItemEnchantmentLevel(enchantEntry, stack);
+	}
+	private static int getElytraStat(ItemStack elytraItem) {
+		var stat = (getLevel(Enchantments.MENDING,elytraItem)*3+1)+getLevel(Enchantments.UNBREAKING,elytraItem);
+
+		return stat;
+	}
+
+	private static int getChestplateStat(ItemStack chestplateItem) {
+		float score = 1;
+
+		if(stackHasComponent(chestplateItem,DataComponents.EQUIPPABLE)){
+			if(chestplateItem.get(DataComponents.EQUIPPABLE).slot()==EquipmentSlot.CHEST){
+				var component = chestplateItem.get(DataComponents.ATTRIBUTE_MODIFIERS);
+				for (ItemAttributeModifiers.Entry entry : component.modifiers()) {
+					Holder<Attribute> attribute = entry.attribute();
+					if(attribute == Attributes.ARMOR) {
+						score += entry.modifier().amount();
+					}
+					if(attribute == Attributes.ARMOR_TOUGHNESS) {
+						score += entry.modifier().amount();
+					}
+				}
+				score += getLevel(Enchantments.PROTECTION,chestplateItem)*2;
+				score += getLevel(Enchantments.MENDING,chestplateItem)*0.5;
+				score += stackHasComponent(chestplateItem,DataComponents.CUSTOM_NAME)?0.25:0;
+				score += getLevel(Enchantments.UNBREAKING,chestplateItem)*0.24/3;
+			}
+		}
+
+		return (int) (score*1000);
+	}
+
+	private static void wearElytra(int slotId) {
+		swap(slotId, Minecraft.getInstance());
+		try {
+			Minecraft.getInstance().getConnection().send(new ServerboundPlayerCommandPacket(Minecraft.getInstance().player, ServerboundPlayerCommandPacket.Action.START_FALL_FLYING));
+			Minecraft.getInstance().player.startFallFlying();
+		} catch (NullPointerException ex) {
+			ex.printStackTrace();
+		}
+	}
+
+
+	private static void swap(int slot, Minecraft client) {
+		int slot2 = slot;
+		if (slot2 == 40) slot2 = 45;
+		if (slot2 < 9) slot2 += 36;
+
+		try {
+			client.gameMode.handleContainerInput(0, slot2, 0, ContainerInput.PICKUP, client.player);
+			client.gameMode.handleContainerInput(0, 6, 0, ContainerInput.PICKUP, client.player);
+			client.gameMode.handleContainerInput(0, slot2, 0, ContainerInput.PICKUP, client.player);
+		} catch (NullPointerException ex) {
+			ex.printStackTrace();
+		}
+	}
+	public static boolean isSlotChestplate(int slotId) {
+
+		if (Minecraft.getInstance().player == null) {
+			return false;
+		}
+		ItemStack chestSlot = Minecraft.getInstance().player.getInventory().getItem(slotId);
+
+		return !chestSlot.isEmpty() &&
+				stackHasComponent(chestSlot,DataComponents.EQUIPPABLE) &&
+				chestSlot.get(DataComponents.EQUIPPABLE).slot() == EquipmentSlot.CHEST &&
+				getLevel(Enchantments.BINDING_CURSE,chestSlot) == 0;
+	}
+
+	private static int[] slotArray() {
+		int[] range = new int[37];
+		for (int i = 0; i < 9; i++) range[i] = 8 - i;
+		for (int i = 9; i < 36; i++) range[i] = 35 - (i - 9);
+		range[36] = 40;
+		return range;
+	}
+
+	public static boolean shouldWearChestplatePrevTick =true;
+	public static void onInitializeClient() {
+		var bind = PLATFORM.registerKeyBind("jjelytraswap.keybind",-1);
+		PLATFORM.registerClientTickEvent(client->{
+			if (client.level == null || client.player == null) {
+				return;
+			}
+
+			if(bind.consumeClick())
+			{
+				enabled=!enabled;
+				var ts = ("jjelytraswap."+(enabled?"enabled":"disabled"));
+				client.gui.hud.getChat().addClientSystemMessage(Component.translatable(ts));
+			}
+			if(!enabled)
+				return;
+			boolean isInAir = !client.player.onGround() && !(client.player.isInWater() || client.player.isInLava());
+			boolean shouldWearChestplate = !isInAir;
+			if(shouldWearChestplate && !shouldWearChestplatePrevTick){
+				if(stackHasComponent(Minecraft.getInstance().player.getItemBySlot(EquipmentSlot.CHEST),DataComponents.GLIDER)){
+					tryWearChestplate(client);
+				}
+			}
+			shouldWearChestplatePrevTick = shouldWearChestplate;
+		});
+
+	}
+}
+*///?}

--- a/src/main/java/io/github/jumperonjava/jjelytraswap/ModPlatform.java
+++ b/src/main/java/io/github/jumperonjava/jjelytraswap/ModPlatform.java
@@ -1,3 +1,4 @@
+//? if <26.2 {
 package io.github.jumperonjava.jjelytraswap;
 
 
@@ -7,7 +8,7 @@ import net.minecraft.client.option.KeyBinding;
 import java.util.function.Consumer;
 
 /**
- * This interface allows you to define platform specific code, and call it in 
+ * This interface allows you to define platform specific code, and call it in
  */
 
 public interface ModPlatform {
@@ -17,3 +18,20 @@ public interface ModPlatform {
 
     KeyBinding registerKeyBind(String translationKeyName, int defaultKeyId);
 }
+//?} else {
+/*package io.github.jumperonjava.jjelytraswap;
+
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.KeyMapping;
+
+import java.util.function.Consumer;
+
+public interface ModPlatform {
+    String getModloader();
+    boolean isModLoaded(String modloader);
+    void registerClientTickEvent(Consumer<Minecraft> o);
+
+    KeyMapping registerKeyBind(String translationKeyName, int defaultKeyId);
+}
+*///?}

--- a/src/main/java/io/github/jumperonjava/jjelytraswap/mixin/SwapCheckMixin.java
+++ b/src/main/java/io/github/jumperonjava/jjelytraswap/mixin/SwapCheckMixin.java
@@ -1,3 +1,4 @@
+//? if <26.2 {
 package io.github.jumperonjava.jjelytraswap.mixin;
 
 import io.github.jumperonjava.jjelytraswap.JJElytraSwapInit;
@@ -25,3 +26,31 @@ public class SwapCheckMixin {
         }
     }
 }
+//?} else {
+/*package io.github.jumperonjava.jjelytraswap.mixin;
+
+import io.github.jumperonjava.jjelytraswap.JJElytraSwapInit;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.world.effect.MobEffects;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+
+@Mixin(LocalPlayer.class)
+public class SwapCheckMixin {
+
+    @Inject(method = "aiStep", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/player/LocalPlayer;tryToStartFallFlying()Z", shift = At.Shift.AFTER))
+    public void swapToElytra(CallbackInfo callbackInfo) {
+        if (!JJElytraSwapInit.enabled)
+            return;
+        var target = ((LocalPlayer) (Object) this);
+        if (!target.onGround() &&
+                !target.isFallFlying()
+                && !target.isInWater() && !target.hasEffect(MobEffects.LEVITATION)) {
+            JJElytraSwapInit.tryWearElytra();
+        }
+    }
+}
+*///?}

--- a/src/main/java/io/github/jumperonjava/jjelytraswap/platforms/fabric/JJElytraSwapFabric.java
+++ b/src/main/java/io/github/jumperonjava/jjelytraswap/platforms/fabric/JJElytraSwapFabric.java
@@ -1,4 +1,4 @@
-//? if fabric {
+//? if fabric && <26.2 {
 /*package io.github.jumperonjava.jjelytraswap.platforms.fabric;
 
 import io.github.jumperonjava.jjelytraswap.ModPlatform;
@@ -48,6 +48,53 @@ public class JJElytraSwapFabric implements ClientModInitializer {
 			KeyBindingHelper.registerKeyBinding(bind);
 			return bind;
 			^///?}
+		}
+	}
+}
+*///?}
+//? if fabric && >=26.2 {
+/*package io.github.jumperonjava.jjelytraswap.platforms.fabric;
+
+import io.github.jumperonjava.jjelytraswap.ModPlatform;
+import io.github.jumperonjava.jjelytraswap.JJElytraSwapInit;
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.keymapping.v1.KeyMappingHelper;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.KeyMapping;
+import net.minecraft.resources.Identifier;
+
+import java.util.function.Consumer;
+
+public class JJElytraSwapFabric implements ClientModInitializer {
+	@Override
+	public void onInitializeClient() {
+		JJElytraSwapInit.entrypoint(new FabricPlatform());
+	}
+	public static class FabricPlatform implements ModPlatform{
+
+		@Override
+		public String getModloader() {
+			return "Fabric";
+		}
+
+		@Override
+		public boolean isModLoaded(String modloader) {
+			return FabricLoader.getInstance().isModLoaded(modloader);
+		}
+
+		@Override
+		public void registerClientTickEvent(Consumer<Minecraft> o) {
+			ClientTickEvents.END_CLIENT_TICK.register(o::accept);
+		}
+
+		@Override
+		public KeyMapping registerKeyBind(String translationKeyName, int defaultKeyId) {
+			KeyMapping.Category kbCategory = new KeyMapping.Category(Identifier.fromNamespaceAndPath("jjelytraswap","generic"));
+			var bind = new KeyMapping(translationKeyName, defaultKeyId, kbCategory);
+			KeyMappingHelper.registerKeyMapping(bind);
+			return bind;
 		}
 	}
 }

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
     id("dev.kikugie.stonecutter")
-    id("dev.architectury.loom") version "1.13-SNAPSHOT" apply false
-    id("architectury-plugin") version "3.4-SNAPSHOT" apply false
+    id("dev.architectury.loom") version "1.17-SNAPSHOT" apply false
+    id("architectury-plugin") version "3.5-SNAPSHOT" apply false
     id("com.gradleup.shadow") version "9.3.0" apply false
     id("me.modmuss50.mod-publish-plugin") version "0.8.4" apply false
 }
-stonecutter active "1.21.11-neoforge" /* [SC] DO NOT EDIT */
+stonecutter active "26.2-fabric" /* [SC] DO NOT EDIT */
 stonecutter.automaticPlatformConstants = true
 
 // Builds every version into `build/libs/{mod.version}/{loader}`
@@ -20,6 +20,16 @@ stonecutter registerChiseled tasks.register("chiseledPublishMods", stonecutter.c
 stonecutter registerChiseled tasks.register("chiseledRunAllClients", stonecutter.chiseled) {
     group = "project"
     ofTask("runClient")
+}
+
+// Builds only the currently active version (stonecutter active "…"). Unlike
+// chiseledBuild (all versions) this chisels + builds just one version, which is
+// what you want when iterating on a single MC version. The versions filter runs
+// lazily, so it doesn't need stonecutter.tree to be populated at registration time.
+stonecutter registerChiseled tasks.register("chiseledBuildActive", stonecutter.chiseled) {
+    group = "project"
+    versions { _, v -> v.isActive }
+    ofTask("buildAndCollect")
 }
 
 

--- a/versions/26.2-fabric/gradle.properties
+++ b/versions/26.2-fabric/gradle.properties
@@ -1,0 +1,29 @@
+mod.mc_dep_fabric==26.2
+mod.mc_dep_forgelike=[26.2]
+mod.mc_title=26.2
+mod.mc_targets=26.2
+
+# DO NOT EDIT UNLESS NEW AW FILE NEEDED
+mod.aw_version=26.2
+
+
+deps.forge_loader=61.0.3
+deps.neoforge_loader=26.2.0.15-beta
+deps.neoforge_patch=1.21+build.4
+
+# Yarn is unavailable for 26.2; build uses Mojang official mappings.
+deps.yarn_build=
+deps.fabric_loader=0.19.3
+deps.fabric_version=0.156.0+26.2
+deps.modmenu_version=20.0.1
+# elytra-recast has no 26.2 build; integration disabled for 26.2
+deps.elytra_recast=
+
+loom.platform=fabric
+
+# 26.2 is unobfuscated (no Yarn/Mojang mappings published). Keep base loom but
+# tell it not to set up obfuscation/mappings, so we compile directly against the
+# official-names Minecraft jar. Remap stays enabled as an identity passthrough
+# (source and target namespaces are both official), which keeps the remapJar task
+# registered (architectury-plugin depends on it) and produces an official-names jar.
+fabric.loom.disableObfuscation=true


### PR DESCRIPTION
Add 26.2-fabric variant for Minecraft 26.2 "Chaos Cubed" (unobfuscated, Mojang-official-mappings only, no Yarn). Migrates the source to 26.2's renamed APIs (Identifier, DataComponents in core.component, ContainerInput, lookupOrThrow, KeyMappingHelper, Gui.hud.getChat().addClientSystemMessage, onGround(), etc.) behind //? if <26.2 forks, leaving all 1.21.x (Yarn) versions untouched. Java 25, Loom 1.17, Gradle 9.5.1, no remapJar path.